### PR TITLE
Add support for queue length limit

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,5 @@ Command line options:
 perl /usr/local/bin/amqp_consumer_opentsdb.pl  \
     --amqp_hosts amqp://user:pass@mq01:5672/monitoring,amqp://user:pass@mq02:5672/monitoring \
     --amqp_exchanges metrics,metrics_amqp \
+    --amqp_queue_max_length 10000 \
     --opentsdb_hosts opentsdb://127.0.0.1:4242,opentsdb://10.10.10.10:4242
-    
-
-

--- a/amqp_consumer_opentsdb.pl
+++ b/amqp_consumer_opentsdb.pl
@@ -15,15 +15,16 @@ my @amqp_hosts;
 my @amqp_exchanges;
 my $amqp_queue = 'consumerqueue';
 my $amqp_topic = '#';
-
+my $amqp_queue_max_length = 0;
 my @opentsdb_hosts;
 
 my $debug = 0;
 
 GetOptions (
-  "amqp_hosts=s" => \@amqp_hosts, 
-  "amqp_exchanges=s" => \@amqp_exchanges, 
-  "amqp_queue=s" => \$amqp_queue, 
+  "amqp_hosts=s" => \@amqp_hosts,
+  "amqp_exchanges=s" => \@amqp_exchanges,
+  "amqp_queue=s" => \$amqp_queue,
+  "amqp_queue_max_length=i" => \$amqp_queue_max_length,
   "amqp_topic=s" => \$amqp_topic,
   "opentsdb_hosts=s" => \@opentsdb_hosts,
   "debug=s" => \$debug
@@ -37,7 +38,7 @@ while(1) {
   ## Pick AMQP/OpenTSDB hosts
   my $amqp = $amqp_hosts[rand(@amqp_hosts)];
   if ($amqp !~ /^amqp:\/\/(.+?):(.+?)@(.+?):(\d+)(.+)$/) {
-    print "Unable to parse AMQP URI\n"; 
+    print "Unable to parse AMQP URI\n";
     exit;
   }
   my $amqp_user = $1;
@@ -47,13 +48,17 @@ while(1) {
   my $amqp_vhost = $5;
   print "$amqp_user : $amqp_pass @ $amqp_host : $amqp_port $amqp_vhost\n" if $debug;
   my $opentsdb = $opentsdb_hosts[rand(@opentsdb_hosts)];
-  
+
   if ($opentsdb !~ /^opentsdb:\/\/(.+?):(\d+)\/?$/) {
     print "Unable to parse opentsdb URI\n";
     exit;
   }
+
   my $opentsdb_host = $1;
   my $opentsdb_port = $2;
+  my $amqp_queue_options = ($amqp_queue_max_length > 0)
+    ? {'x-max-length' => $amqp_queue_max_length}
+    : {};
 
   print "Connecting to opentsdb: $opentsdb\n" if $debug;
   my $sock;
@@ -71,7 +76,7 @@ while(1) {
     $mq = Net::RabbitMQ->new();
     $mq->connect($amqp_host , { port => $amqp_port, user => $amqp_user, password => $amqp_pass, vhost => $amqp_vhost });
     $mq->channel_open(1);
-    $mq->queue_declare(1, $amqp_queue);
+    $mq->queue_declare(1, $amqp_queue, {}, $amqp_queue_options);
     foreach my $ex (@amqp_exchanges) {
       $mq->queue_bind(1, $amqp_queue, $ex, $amqp_topic);
     }
@@ -107,7 +112,7 @@ while(1) {
           $tk =~ s/[ =]//g;
           $metric->{$k} =~ s/[ =]//g;
           $output .= ' ' . $tk . '=' . $metric->{$k};
-        } 
+        }
         $output .= "\n";
         ## Should be using select to see if the socket is ready.... Ah well....
         my $len = length($output);


### PR DESCRIPTION
Had o problem this weekend :smile:,

Not sure if the process got stuck or if opentsdb couldn't handle the number of messages
But while the perl process was alive rabbit keep the queue alive and growing rapidly which brought down one of the rabbit nodes.

Setting a queue length limit should prevent it from happening again.
